### PR TITLE
Run tests on Travis CI and fix Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+
+install:
+  - pip install numpy pytest
+
+cache: pip
+
+script:
+  - pytest --ignore groupy/gconv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 
 install:
   - pip install numpy pytest

--- a/experiments/AID/aid.py
+++ b/experiments/AID/aid.py
@@ -3,7 +3,6 @@ import os
 import numpy as np
 from groupy.hexa.hexa_sample import sample_cartesian2hexa
 from groupy import hexa
-import sys
 from os.path import join, isdir
 import scipy.misc
 
@@ -84,17 +83,17 @@ def split(all_images, fraction=0.5, seed=None):
 
 
 def preprocess_aid(datadir, hex_sampling, seed):
-    print 'Preprocessing...'
+    print('Preprocessing...')
 
     # Load batches
-    print '   Loading...'
+    print('   Loading...')
 
     paths = [[join(datadir, path, i) for i in os.listdir(join(datadir, path))
               if len(i) > 4 and i[-4:] == '.jpg']
              for path in os.listdir(datadir)
              if isdir(join(datadir, path))]
 
-    print '   Loading images...'
+    print('   Loading images...')
     all_images = [[scipy.misc.imresize(
                         scipy.misc.imread(image), (64, 64)).transpose(2, 0, 1)
                    for image in path]
@@ -113,7 +112,7 @@ def preprocess_aid(datadir, hex_sampling, seed):
     if hex_sampling == '':
         mask = np.ones(train_data_all.shape[-2:], dtype='bool')
     elif hex_sampling == 'axial':
-        print '   Hex sampling...'
+        print('   Hex sampling...')
         train_data_all = _sample_hex_axial(train_data_all)
         test_data = _sample_hex_axial(test_data)
 
@@ -126,7 +125,7 @@ def preprocess_aid(datadir, hex_sampling, seed):
     test_data_no_padding = test_data[..., mask]
 
     # Contrast normalize
-    print '   Normalizing...'
+    print('   Normalizing...')
     train_data_all_no_padding = normalize(train_data_all_no_padding)
     test_data_no_padding = normalize(test_data_no_padding)
 
@@ -134,7 +133,7 @@ def preprocess_aid(datadir, hex_sampling, seed):
 
     test_data[..., mask] = test_data_no_padding
 
-    print '   Saving...'
+    print('   Saving...')
     outputdir = get_preprocess_folder(datadir, hex_sampling, seed)
     if not os.path.exists(outputdir):
         os.mkdir(outputdir)
@@ -145,7 +144,7 @@ def preprocess_aid(datadir, hex_sampling, seed):
              data=test_data,
              labels=test_labels)
 
-    print 'Preprocessing complete'
+    print('Preprocessing complete')
 
 
 def _load_cifar10_batch(file):

--- a/experiments/CIFAR10/cifar10.py
+++ b/experiments/CIFAR10/cifar10.py
@@ -152,10 +152,10 @@ def get_cifar10_data(datadir, trainfn, valfn, hex_sampling=''):
 
 
 def preprocess_cifar10(datadir, hex_sampling=''):
-    print 'Preprocessing...'
+    print('Preprocessing...')
 
     # Load batches
-    print '   Loading...'
+    print('   Loading...')
 
     load_cifar_fc = _load_cifar10_batch
 
@@ -184,7 +184,7 @@ def preprocess_cifar10(datadir, hex_sampling=''):
     if hex_sampling == '':
         mask = np.ones(train_data_all.shape[-2:], dtype='bool')
     elif hex_sampling == 'axial':
-        print '   Hex sampling...'
+        print('   Hex sampling...')
         train_data_all = _sample_hex_axial(train_data_all)
         train_data = _sample_hex_axial(train_data)
         test_data = _sample_hex_axial(test_data)
@@ -195,7 +195,7 @@ def preprocess_cifar10(datadir, hex_sampling=''):
     else:
         raise ValueError('Unknown option "{}"'.format(hex_sampling))
 
-    print 'Saving a few examples...'
+    print('Saving a few examples...')
     save_images(datadir, list(train_data[:10]),
                 hex_sampling=hex_sampling)
 
@@ -205,13 +205,13 @@ def preprocess_cifar10(datadir, hex_sampling=''):
     test_data_no_padding = test_data[..., mask]
 
     # Contrast normalize
-    print '   Normalizing...'
+    print('   Normalizing...')
     train_data_all_no_padding = normalize(train_data_all_no_padding)
     train_data_no_padding = normalize(train_data_no_padding)
     val_data_no_padding = normalize(val_data_no_padding)
     test_data_no_padding = normalize(test_data_no_padding)
 
-    print '   Computing whitening matrix...'
+    print('   Computing whitening matrix...')
     train_data_all_flat = train_data_all_no_padding.reshape(
         train_data_all.shape[0], -1).T
     train_data_flat = train_data_no_padding.reshape(train_data.shape[0], -1).T
@@ -221,7 +221,7 @@ def preprocess_cifar10(datadir, hex_sampling=''):
     pca_all = PCA(
         D=train_data_all_flat, n_components=train_data_all_flat.shape[1])
 
-    print '   Whitening data...'
+    print('   Whitening data...')
     train_data_all_flat = pca_all.transform(
                             D=train_data_all_flat, whiten=True, ZCA=True)
 
@@ -253,7 +253,7 @@ def preprocess_cifar10(datadir, hex_sampling=''):
     # test_data[..., mask] = global_contrast_normalize(test_data_flat).reshape(
     #         test_data_no_padding.shape)
 
-    print '   Saving...'
+    print('   Saving...')
     outputdir = get_preprocess_folder(datadir, hex_sampling)
     if not os.path.exists(outputdir):
         os.mkdir(outputdir)
@@ -270,7 +270,7 @@ def preprocess_cifar10(datadir, hex_sampling=''):
              data=test_data,
              labels=test_labels)
 
-    print 'Preprocessing complete'
+    print('Preprocessing complete')
 
 
 def _load_cifar10_batch(file):

--- a/experiments/paper_plots.py
+++ b/experiments/paper_plots.py
@@ -149,14 +149,14 @@ def testplot_p4m(im=None, m=0, r=0):
     filter_mr2 = rotate_flip_z2_func(filter_e, flip=1, theta_index=2)
     filter_mr3 = rotate_flip_z2_func(filter_e, flip=1, theta_index=3)
 
-    print filter_e
-    print filter_r1
-    print filter_r2
-    print filter_r3
-    print filter_m
-    print filter_mr1
-    print filter_mr2
-    print filter_mr3
+    print(filter_e)
+    print(filter_r1)
+    print(filter_r2)
+    print(filter_r3)
+    print(filter_m)
+    print(filter_mr1)
+    print(filter_mr2)
+    print(filter_mr3)
 
     # filter_e = filter_e[::-1, ::-1]
     # filter_r1 = filter_r1[::-1, ::-1]

--- a/groupy/garray/__init__.py
+++ b/groupy/garray/__init__.py
@@ -1,8 +1,7 @@
-
-from p4_array import P4Array
-from p4m_array import P4MArray
-from Z2_array import Z2Array
-from Z3_array import Z3Array
-from C4_array import C4Array
-from D4_array import D4Array
-from m3m_array import M3MArray
+from groupy.garray.p4_array import P4Array
+from groupy.garray.p4m_array import P4MArray
+from groupy.garray.Z2_array import Z2Array
+from groupy.garray.Z3_array import Z3Array
+from groupy.garray.C4_array import C4Array
+from groupy.garray.D4_array import D4Array
+from groupy.garray.m3m_array import M3MArray

--- a/groupy/gconv/gconv_chainer/kernels/test_integer_indexing_cuda_kernel.py
+++ b/groupy/gconv/gconv_chainer/kernels/test_integer_indexing_cuda_kernel.py
@@ -24,6 +24,5 @@ def test_index_group_func():
     cpoutput = cuda.to_cpu(cpoutput)
 
     error = np.abs(cpoutput - output).sum()
-    print error
+    print(error)
     assert np.isclose(error, 0.)
-

--- a/groupy/gconv/gconv_chainer/test_gconv.py
+++ b/groupy/gconv/gconv_chainer/test_gconv.py
@@ -226,7 +226,7 @@ def check_equivariance(im, layers, input_array, output_array, point_group):
 
     fmap_data = cuda.to_cpu(fmap.data)
 
-    print fmap_data
+    print(fmap_data)
     assert np.allclose(fmap_data, r_fmap1_data, rtol=1e-5, atol=1e-3)
 
 

--- a/groupy/gconv/gconv_chainer/test_transform_filter.py
+++ b/groupy/gconv/gconv_chainer/test_transform_filter.py
@@ -88,5 +88,5 @@ def check_transform_grad(inds, w, transformer, dtype, toll):
 
     relerr = np.max(np.abs(gan - gat) / np.maximum(np.abs(gan), np.abs(gat)))
 
-    print dtype, toll, relerr
+    print(dtype, toll, relerr)
     assert relerr < toll

--- a/groupy/gfunc/__init__.py
+++ b/groupy/gfunc/__init__.py
@@ -1,4 +1,3 @@
-
-from p4func_array import P4FuncArray
-from p4mfunc_array import P4MFuncArray
-from z2func_array import Z2FuncArray
+from groupy.gfunc.p4func_array import P4FuncArray
+from groupy.gfunc.p4mfunc_array import P4MFuncArray
+from groupy.gfunc.z2func_array import Z2FuncArray

--- a/groupy/gfunc/p6_axial_func_array.py
+++ b/groupy/gfunc/p6_axial_func_array.py
@@ -61,4 +61,4 @@ def tst():
 
     gfp = f(lp)
 
-    print gfp
+    print(gfp)

--- a/groupy/gfunc/p6m_axial_func_array.py
+++ b/groupy/gfunc/p6m_axial_func_array.py
@@ -71,4 +71,4 @@ def tst():
 
     gfp = f(lp)
 
-    print gfp
+    print(gfp)

--- a/groupy/grids/hexa_lattice.py
+++ b/groupy/grids/hexa_lattice.py
@@ -138,7 +138,7 @@ def hexa_manhattan_dist(n11, n12, n21, n22):
 
 
 def zigzaghexa_manhattan_dist(m11, m12, m21, m22):
-    print 'untested'  # TODO
+    print('untested')  # TODO
     n11, n12 = zigzaghexa2hexa(m11, m12)
     n21, n22 = zigzaghexa2hexa(m21, m22)
     return hexa_manhattan_dist(n11, n12, n21, n22)
@@ -157,7 +157,7 @@ def plot_c2o():
     m1, m2 = np.meshgrid(np.arange(minm, maxm + 1), np.arange(minm, maxm + 1))
 
     x, y = zigzaghexa2cartesian(m1, m2)
-    print x.shape
+    print(x.shape)
 
     plt.scatter(x, y, c=m1)
     plt.figure()

--- a/groupy/hexa/hexa_lattice.py
+++ b/groupy/hexa/hexa_lattice.py
@@ -138,7 +138,7 @@ def hexa_manhattan_dist(n11, n12, n21, n22):
 
 
 def zigzaghexa_manhattan_dist(m11, m12, m21, m22):
-    print 'untested'  # TODO
+    print('untested')  # TODO
     n11, n12 = zigzaghexa2hexa(m11, m12)
     n21, n22 = zigzaghexa2hexa(m21, m22)
     return hexa_manhattan_dist(n11, n12, n21, n22)
@@ -157,7 +157,7 @@ def plot_c2o():
     m1, m2 = np.meshgrid(np.arange(minm, maxm + 1), np.arange(minm, maxm + 1))
 
     x, y = zigzaghexa2cartesian(m1, m2)
-    print x.shape
+    print(x.shape)
 
     plt.scatter(x, y, c=m1)
     plt.figure()

--- a/groupy/hexa/hexa_plot_mpl.py
+++ b/groupy/hexa/hexa_plot_mpl.py
@@ -165,7 +165,7 @@ def hexa_plot(f):
     fig=plt.figure(figsize=(10, 10))
     ax = fig.add_subplot(111)
 
-    print x.shape, y.shape, f.shape
+    print(x.shape, y.shape, f.shape)
     # Set gridsize just to make them visually large
     image = plt.hexbin(
             x.flatten(), y.flatten(),

--- a/groupy/plot/plot_p4.py
+++ b/groupy/plot/plot_p4.py
@@ -129,7 +129,7 @@ def paper_plots(i=0, ll=1., ul=0.4, cmap1=cm.Blues, cmap2=cm.Greens):
         rf_f = rf * f
         return rf_f.v
 
-    print p4m_fmaps.shape
+    print(p4m_fmaps.shape)
     r_p4m_fmaps = rotate_flip_p4m_func(p4m_fmaps.transpose(3, 0, 1, 2), 0, 1).transpose(1, 2, 3, 0)
     from groupy.plot.plot_p4m import plot_p4m
     # imf.reshape(2, 4, 7, 7), rlabels = 'cayley2', fontsize = 10,

--- a/groupy/plot/plot_p4m.py
+++ b/groupy/plot/plot_p4m.py
@@ -343,14 +343,14 @@ def testplot(im=None, m=0, r=0):
     filter_mr2 = rotate_flip_z2_func(filter_e, flip=1, theta_index=2)
     filter_mr3 = rotate_flip_z2_func(filter_e, flip=1, theta_index=3)
 
-    print filter_e
-    print filter_r1
-    print filter_r2
-    print filter_r3
-    print filter_m
-    print filter_mr1
-    print filter_mr2
-    print filter_mr3
+    print(filter_e)
+    print(filter_r1)
+    print(filter_r2)
+    print(filter_r3)
+    print(filter_m)
+    print(filter_mr1)
+    print(filter_mr2)
+    print(filter_mr3)
 
     # filter_e = filter_e[::-1, ::-1]
     # filter_r1 = filter_r1[::-1, ::-1]

--- a/train_aid.py
+++ b/train_aid.py
@@ -169,7 +169,7 @@ def train(
 
     # Get number of parameters
     if hasattr(model, 'number_of_params'):
-        print "Computing number of parameters with specialized script"
+        print("Computing number of parameters with specialized script")
         num_params = model.number_of_params()
         naive_params = sum([p.data.size for p in model.params()])
         logging.info('Number of parameters: {:.2f} (Original: {})'.format(
@@ -294,8 +294,8 @@ if __name__ == '__main__':
     with cp.cuda.Device(vargs['gpu']):
         val_error, model = train(logme=vargs, **vargs)
 
-    print 'Finished training'
-    print 'Final validation error:', val_error
-    print 'Saving model...'
+    print('Finished training')
+    print('Final validation error:', val_error)
+    print('Saving model...')
     import chainer.serializers as sl
     sl.save_hdf5('./my.model', model)

--- a/train_cifar.py
+++ b/train_cifar.py
@@ -168,7 +168,7 @@ def train(
 
     # Get number of parameters
     if hasattr(model, 'number_of_params'):
-        print "Computing number of parameters with specialized script"
+        print("Computing number of parameters with specialized script")
         num_params = model.number_of_params()
         naive_params = sum([p.data.size for p in model.params()])
         logging.info('Number of parameters: {:.2f} (Original: {})'.format(
@@ -290,8 +290,8 @@ if __name__ == '__main__':
     with cp.cuda.Device(vargs['gpu']):
         val_error, model = train(logme=vargs, **vargs)
 
-    print 'Finished training'
-    print 'Final validation error:', val_error
-    print 'Saving model...'
+    print('Finished training')
+    print('Final validation error:', val_error)
+    print('Saving model...')
     import chainer.serializers as sl
     sl.save_hdf5('./my.model', model)


### PR DESCRIPTION
Thanks for making this code public!

This PR adds the possibility to run the tests on [Travis CI](http://travis-ci.org/). Just enable [Travis CI](http://travis-ci.org/) for this repo in order to run the unit tests on every push and pull request.

Here is am example build on Travis CI: https://travis-ci.org/lgeiger/hexaconv/builds/346884358

Currently this ignores the `chainer` tests because `cupy` failed to install on Travis.